### PR TITLE
Fix the build on darwin.

### DIFF
--- a/libpng.lisp
+++ b/libpng.lisp
@@ -2,7 +2,7 @@
 
 
 (define-foreign-library libpng
-  (:darwin "libpng12.0.dylib")
+  (:darwin (:or "libpng12.0.dylib" "libpng16.dylib"))
   (t (:or "libpng12.so" "libpng16.so" "libpng.so")))
 
 (use-foreign-library libpng)
@@ -154,8 +154,6 @@
     (setq ver (/ (- ver minor) 100))
     (format nil "~d.~d.~d" ver minor micro)))
 
-(defconstant +png-libpng-ver-string+ (get-png-version-string))
-
 (defvar *stream*)
 
 (defvar *buffer*)
@@ -208,7 +206,7 @@
     `(let ((,var (,(ecase direction
 			  (:input 'png-create-read-struct)
 			  (:output 'png-create-write-struct))
-		   +png-libpng-ver-string+ (null-pointer)
+		   (get-png-version-string) (null-pointer)
 		   (callback error-fn) (callback warn-fn)))
 	   (*buffer* (make-shareable-byte-vector 1024)))
        (when (null-pointer-p ,var)


### PR DESCRIPTION
You may not want to merge this as I'm not sure you're actively maintaining your cl-png fork. I only made my fork to do some throwaway testing of my NES emulator. That said, this makes your cl-png build on darwin and avoids the compile-time dependency on an alien function `png_access_version_number` that I couldn't seem to work around with `eval-when`. :+1: